### PR TITLE
[LTD] Bump apache-airflow version to address security vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.14.44
-apache-airflow==2.1.1
+apache-airflow==2.1.3
 Faker==4.0.0
 black==21.6b0
 isort==5.9.2


### PR DESCRIPTION
## Change description

Bump `apache-airflow` version to `2.1.3 (latest stable version)` to address a security vulnerability flagged by dependabot