### PR TITLE
[LTD-4696] Exclude document data table from Lite DB dump

### DIFF
--- a/dags/export_lite_db.py
+++ b/dags/export_lite_db.py
@@ -58,7 +58,7 @@ with DAG(
 
     dump_db_operator = BashOperator(
         task_id="dump_db",
-        bash_command=f"pg_dump {ANON_VARS.LITE_DB_URL} >"
+        bash_command=f"pg_dump {ANON_VARS.LITE_DB_URL} --exclude-table-data=document_data_documentdata >"
         f"{Variable.get('sql_dumpfile')}",
         dag=dag,
     )


### PR DESCRIPTION
Ensure that the DocumentData table contents are excluded from lite DB dumps.